### PR TITLE
JAD-5 Issues backend

### DIFF
--- a/src/main/java/ro/ubbcluj/tpjad/jadbackend/controllers/IssueController.java
+++ b/src/main/java/ro/ubbcluj/tpjad/jadbackend/controllers/IssueController.java
@@ -1,0 +1,54 @@
+package ro.ubbcluj.tpjad.jadbackend.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ro.ubbcluj.tpjad.jadbackend.dtos.IssueGetDto;
+import ro.ubbcluj.tpjad.jadbackend.dtos.IssuePostDto;
+import ro.ubbcluj.tpjad.jadbackend.dtos.IssuePutDto;
+import ro.ubbcluj.tpjad.jadbackend.services.IssueService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/projects")
+@CrossOrigin
+public class IssueController {
+    private final IssueService issueService;
+
+    @Autowired
+    public IssueController(IssueService issueService) {
+        this.issueService = issueService;
+    }
+
+    @GetMapping("{projectId}/issues")
+    public ResponseEntity<List<IssueGetDto>> getAllIssuesForProject(@PathVariable Long projectId) {
+        var issues = issueService.getAllIssuesForProject(projectId);
+
+        return new ResponseEntity<>(issues, HttpStatus.OK);
+    }
+
+    @PostMapping("{projectId}/issues")
+    public ResponseEntity<IssueGetDto> createIssueInProject(@PathVariable Long projectId, @RequestBody IssuePostDto issuePostDto) {
+        IssueGetDto createdIssue = issueService.createIssueInProject(issuePostDto, projectId);
+
+        return new ResponseEntity<>(createdIssue, HttpStatus.CREATED);
+    }
+
+    @PutMapping("{projectId}/issues/{issueId}")
+    public ResponseEntity<IssueGetDto> updateIssueInProject(
+            @PathVariable Long projectId, @PathVariable Long issueId, @RequestBody IssuePutDto issuePutDto) {
+        IssueGetDto updatedIssue = issueService.updateIssueInProject(issuePutDto, projectId, issueId);
+
+        return new ResponseEntity<>(updatedIssue, HttpStatus.OK);
+    }
+
+    @DeleteMapping("{projectId}/issues/{issueId}")
+    public ResponseEntity<Void> deleteIssueFromProject(
+            @PathVariable Long projectId, @PathVariable Long issueId) {
+        issueService.deleteIssueFromProject(issueId, projectId);
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/ro/ubbcluj/tpjad/jadbackend/dtos/DtoMapper.java
+++ b/src/main/java/ro/ubbcluj/tpjad/jadbackend/dtos/DtoMapper.java
@@ -1,6 +1,7 @@
 package ro.ubbcluj.tpjad.jadbackend.dtos;
 
 import org.springframework.stereotype.Component;
+import ro.ubbcluj.tpjad.jadbackend.models.Issue;
 import ro.ubbcluj.tpjad.jadbackend.models.Project;
 import ro.ubbcluj.tpjad.jadbackend.models.ProjectMember;
 
@@ -38,5 +39,23 @@ public class DtoMapper {
         return projectMembers.stream()
             .map(this::convertProjectMember)
             .toList();
+    }
+
+    public IssueGetDto convertIssue(Issue issue) {
+        return new IssueGetDto(
+                issue.getId(),
+                issue.getSummary(),
+                issue.getDescription(),
+                issue.getType().name(),
+                issue.getStatus().name(),
+                formatter.format(issue.getDate()),
+                issue.getAssignee().getUsername()
+        );
+    }
+
+    public List<IssueGetDto> convertIssues(List<Issue> issues) {
+        return issues.stream()
+                .map(this::convertIssue)
+                .toList();
     }
 }

--- a/src/main/java/ro/ubbcluj/tpjad/jadbackend/dtos/IssueGetDto.java
+++ b/src/main/java/ro/ubbcluj/tpjad/jadbackend/dtos/IssueGetDto.java
@@ -1,0 +1,14 @@
+package ro.ubbcluj.tpjad.jadbackend.dtos;
+
+import lombok.Data;
+
+@Data
+public class IssueGetDto {
+    private final long id;
+    private final String summary;
+    private final String description;
+    private final String type;
+    private final String status;
+    private final String date;
+    private final String assignee;
+}

--- a/src/main/java/ro/ubbcluj/tpjad/jadbackend/dtos/IssuePostDto.java
+++ b/src/main/java/ro/ubbcluj/tpjad/jadbackend/dtos/IssuePostDto.java
@@ -1,0 +1,13 @@
+package ro.ubbcluj.tpjad.jadbackend.dtos;
+
+import lombok.Data;
+
+@Data
+public class IssuePostDto {
+    private final String summary;
+    private final String description;
+    private final String type;
+    private final String status;
+    private final String date;
+    private final String assignee;
+}

--- a/src/main/java/ro/ubbcluj/tpjad/jadbackend/dtos/IssuePutDto.java
+++ b/src/main/java/ro/ubbcluj/tpjad/jadbackend/dtos/IssuePutDto.java
@@ -1,0 +1,13 @@
+package ro.ubbcluj.tpjad.jadbackend.dtos;
+
+import lombok.Data;
+
+@Data
+public class IssuePutDto {
+    private final String summary;
+    private final String description;
+    private final String type;
+    private final String status;
+    private final String date;
+    private final String assignee;
+}

--- a/src/main/java/ro/ubbcluj/tpjad/jadbackend/repositories/IssueRepository.java
+++ b/src/main/java/ro/ubbcluj/tpjad/jadbackend/repositories/IssueRepository.java
@@ -7,9 +7,14 @@ import org.springframework.stereotype.Repository;
 import ro.ubbcluj.tpjad.jadbackend.models.Issue;
 import ro.ubbcluj.tpjad.jadbackend.repositories.custom.CustomIssueRepository;
 
+import java.util.List;
+
 @Repository
 public interface IssueRepository extends JpaRepository<Issue, Long>, CustomIssueRepository<Long> {
     @Query("delete from Issue i where i.project.id=:projectId")
     @Modifying
     void deleteAllByProjectId(Long projectId);
+
+    @Query("select i from Issue as i where i.project.id=:projectId")
+    List<Issue> findIssuesByProject(Long projectId);
 }

--- a/src/main/java/ro/ubbcluj/tpjad/jadbackend/services/IssueService.java
+++ b/src/main/java/ro/ubbcluj/tpjad/jadbackend/services/IssueService.java
@@ -1,0 +1,14 @@
+package ro.ubbcluj.tpjad.jadbackend.services;
+
+import ro.ubbcluj.tpjad.jadbackend.dtos.IssueGetDto;
+import ro.ubbcluj.tpjad.jadbackend.dtos.IssuePostDto;
+import ro.ubbcluj.tpjad.jadbackend.dtos.IssuePutDto;
+
+import java.util.List;
+
+public interface IssueService {
+    List<IssueGetDto> getAllIssuesForProject(Long projectId);
+    IssueGetDto createIssueInProject(IssuePostDto issue, Long projectId);
+    IssueGetDto updateIssueInProject(IssuePutDto issue, Long projectId, Long issueId);
+    void deleteIssueFromProject(Long issueId, Long projectId);
+}

--- a/src/main/java/ro/ubbcluj/tpjad/jadbackend/services/IssueServiceImpl.java
+++ b/src/main/java/ro/ubbcluj/tpjad/jadbackend/services/IssueServiceImpl.java
@@ -1,0 +1,134 @@
+package ro.ubbcluj.tpjad.jadbackend.services;
+
+import org.springframework.stereotype.Service;
+import ro.ubbcluj.tpjad.jadbackend.dtos.DtoMapper;
+import ro.ubbcluj.tpjad.jadbackend.dtos.IssueGetDto;
+import ro.ubbcluj.tpjad.jadbackend.dtos.IssuePostDto;
+import ro.ubbcluj.tpjad.jadbackend.dtos.IssuePutDto;
+import ro.ubbcluj.tpjad.jadbackend.exceptions.entity.EntityNotFoundException;
+import ro.ubbcluj.tpjad.jadbackend.exceptions.entity.InvalidEntityException;
+import ro.ubbcluj.tpjad.jadbackend.models.*;
+import ro.ubbcluj.tpjad.jadbackend.repositories.IssueRepository;
+import ro.ubbcluj.tpjad.jadbackend.repositories.ProjectRepository;
+import ro.ubbcluj.tpjad.jadbackend.repositories.UserRepository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+@Service
+public class IssueServiceImpl implements IssueService{
+    private final IssueRepository issueRepository;
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final DtoMapper dtoMapper;
+
+    public IssueServiceImpl(IssueRepository issueRepository, UserRepository userRepository,
+                            ProjectRepository projectRepository, DtoMapper dtoMapper) {
+        this.issueRepository = issueRepository;
+        this.userRepository = userRepository;
+        this.projectRepository = projectRepository;
+        this.dtoMapper = dtoMapper;
+    }
+
+    @Override
+    public List<IssueGetDto> getAllIssuesForProject(Long projectId) {
+        var issues = issueRepository.findIssuesByProject(projectId);
+        return dtoMapper.convertIssues(issues);
+    }
+
+    @Override
+    public IssueGetDto createIssueInProject(IssuePostDto issuePostDto, Long projectId) {
+        var project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException(projectId, Project.class.getSimpleName()));
+
+        var username = issuePostDto.getAssignee();
+        var assignee = userRepository.findByUsername(username)
+                .orElseThrow(() -> new InvalidEntityException("Invalid assignee provided"));
+
+        IssueStatus issueStatus;
+        try {
+            issueStatus = IssueStatus.valueOf(issuePostDto.getStatus());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidEntityException("Invalid status provided", e);
+        }
+
+        IssueType issueType;
+        try {
+            issueType = IssueType.valueOf(issuePostDto.getType());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidEntityException("Invalid type provided", e);
+        }
+
+        LocalDateTime date;
+        try {
+            date = LocalDateTime.parse(issuePostDto.getDate(), DtoMapper.formatter);
+        } catch (DateTimeParseException e) {
+            throw new InvalidEntityException("Invalid date provided", e);
+        }
+
+        var issue = new Issue(
+                null,
+                issuePostDto.getSummary(),
+                issuePostDto.getDescription(),
+                issueType,
+                issueStatus,
+                date,
+                project,
+                assignee
+        );
+
+        Issue savedIssue = issueRepository.save(issue);
+
+        return dtoMapper.convertIssue(savedIssue);
+    }
+
+    @Override
+    public IssueGetDto updateIssueInProject(IssuePutDto issuePutDto, Long projectId, Long issueId) {
+        var issue = issueRepository.findById(issueId)
+                .orElseThrow(() -> new EntityNotFoundException(issueId, Issue.class.getSimpleName()));
+
+        var username = issuePutDto.getAssignee();
+        var assignee = userRepository.findByUsername(username)
+                .orElseThrow(() -> new InvalidEntityException("Invalid assignee provided"));
+
+        IssueStatus issueStatus;
+        try {
+            issueStatus = IssueStatus.valueOf(issuePutDto.getStatus());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidEntityException("Invalid status provided", e);
+        }
+
+        IssueType issueType;
+        try {
+            issueType = IssueType.valueOf(issuePutDto.getType());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidEntityException("Invalid type provided", e);
+        }
+
+        LocalDateTime date;
+        try {
+            date = LocalDateTime.parse(issuePutDto.getDate(), DtoMapper.formatter);
+        } catch (DateTimeParseException e) {
+            throw new InvalidEntityException("Invalid date provided", e);
+        }
+
+        issue.setSummary(issuePutDto.getSummary());
+        issue.setDescription(issuePutDto.getDescription());
+        issue.setType(issueType);
+        issue.setStatus(issueStatus);
+        issue.setDate(date);
+        issue.setAssignee(assignee);
+
+        Issue updatedIssue = issueRepository.save(issue);
+        return dtoMapper.convertIssue(updatedIssue);
+    }
+
+    @Override
+    public void deleteIssueFromProject(Long issueId, Long projectId) {
+        issueRepository.findById(issueId)
+                .orElseThrow(() -> new EntityNotFoundException(issueId, Issue.class.getSimpleName()));
+
+        issueRepository.deleteByIdCascade(issueId);
+    }
+}

--- a/src/test/java/ro/ubbcluj/tpjad/jadbackend/IssueTests.java
+++ b/src/test/java/ro/ubbcluj/tpjad/jadbackend/IssueTests.java
@@ -1,6 +1,5 @@
 package ro.ubbcluj.tpjad.jadbackend;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +18,6 @@ public class IssueTests {
     private WebTestClient webTestClient;
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     void getAllIssues_success() {
         UserLoginGetDto tokenDetails = TestUtils.loginUser(webTestClient, "mihai", "mihai");
@@ -42,7 +40,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     void getAllIssues_success_emptyList() {
         UserLoginGetDto tokenDetails = TestUtils.loginUser(webTestClient, "alex", "alex");
@@ -62,7 +59,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void createIssue_success() {
@@ -85,7 +81,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     void createIssue_failed_invalidType() {
         UserLoginGetDto tokenDetails = TestUtils.loginUser(webTestClient, "mihai", "mihai");
@@ -107,7 +102,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     void createIssue_failed_invalidDate() {
         UserLoginGetDto tokenDetails = TestUtils.loginUser(webTestClient, "mihai", "mihai");
@@ -129,7 +123,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void updateIssue_success() {
@@ -152,7 +145,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     void updateIssue_failed_invalidAssignee() {
         UserLoginGetDto tokenDetails = TestUtils.loginUser(webTestClient, "alex", "alex");
@@ -174,7 +166,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     void updateIssue_failed_invalidStatus() {
         UserLoginGetDto tokenDetails = TestUtils.loginUser(webTestClient, "alex", "alex");
@@ -196,7 +187,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     void updateIssue_failed_issueNotFound() {
         UserLoginGetDto tokenDetails = TestUtils.loginUser(webTestClient, "alex", "alex");
@@ -218,7 +208,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void deleteIssue_success() {
@@ -234,7 +223,6 @@ public class IssueTests {
     }
 
     @Test
-    @Disabled
     @Tag("JAD-5")
     void deleteIssue_failed_issueNotFound() {
         UserLoginGetDto tokenDetails = TestUtils.loginUser(webTestClient, "alex", "alex");

--- a/src/test/java/ro/ubbcluj/tpjad/jadbackend/IssueTests.java
+++ b/src/test/java/ro/ubbcluj/tpjad/jadbackend/IssueTests.java
@@ -248,7 +248,7 @@ public class IssueTests {
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
             .expectBody()
             .json(
-                "{\"errorMessage\": \"Entity 'Comment' with id '10' not found.\"}",
+                "{\"errorMessage\": \"Entity 'Issue' with id '10' not found.\"}",
                 JsonCompareMode.LENIENT
             );
     }


### PR DESCRIPTION
Hopefully we'll be able to merge this without too many changes.
* I've enabled all the tests for JAD-5 (had to modify one because it expected a `Comment` entity to not be found, prolly a copy-paste error).
*  All tests pass, including all previously activated ones.
* The code duplication in `IssueServiceImpl` is intentional. The data extraction logic might look the same, but the structures of `IssuePostDto` and `IssuePutDto` could conceivably diverge in the future (and I can't think of a good way to abstract it away).